### PR TITLE
Parallelize API requests

### DIFF
--- a/src/services/pokemon.ts
+++ b/src/services/pokemon.ts
@@ -17,20 +17,17 @@ type PokeApiPokemon = {
 };
 
 export const getPokemon = async () => {
-  let stats: Pokemon[] = [];
   const response = await fetch("https://pokeapi.co/api/v2/pokemon");
   const data: PokeApiResults = await response.json();
 
-  for (const result of data.results) {
-    const response2 = await fetch(result.url);
-    const data2: PokeApiPokemon = await response2.json();
-    const pokemonStats: Pokemon = {
-      key: data2.id,
-      name: data2.species.name,
-      url: data2.species.url,
-      front_image: data2.sprites.front_default,
-    };
-    stats.push(pokemonStats);
-  }
-  return stats;
+  return Promise.all(
+    data.results.map((result) => fetch(result.url).then((r) => r.json()))
+  ).then((results: PokeApiPokemon[]) =>
+    results.map((result) => ({
+      key: result.id,
+      name: result.species.name,
+      url: result.species.url,
+      front_image: result.sprites.front_default,
+    }))
+  );
 };


### PR DESCRIPTION
The API requests were previously in a series loop where one would need to finish and push onto the array
before the next fetch could start.

Using Promise.all allows us to run all of the fetches at the same time and only push them onto the array when all are done.

1500ms -> 500ms.

<table>
<tr>
<td>
Waterfall <br>
<img src="https://user-images.githubusercontent.com/3998604/209981857-4b89c09d-72ea-4709-b89d-f89bf2c02397.png" />
</td>
<td>
Parallel <br>
<img src="https://user-images.githubusercontent.com/3998604/209981932-7d9648cf-94be-42d1-aac9-2bfde497faea.png" />

</td>
</tr>
</table>
