### PR TITLE
Use toLowerCase() to return a lowercase string for doing match compar…

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -97,7 +97,7 @@ export const App = () => {
   const matchHandler = (match: string) => {
     if (typeAheadNames) {
       const matches = typeAheadNames.filter((name) => {
-        return name.includes(match);
+        return name.includes(match.toLowerCase());
       });
       setMatches(matches);
     }


### PR DESCRIPTION
Use toLowerCase() to return a lowercase string for doing match compaisons in type-ahead feature.